### PR TITLE
Buildsystem changes to make clandmark easier to use

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,11 @@
-cmake_minimum_required( VERSION 2.8.9 )
+cmake_minimum_required( VERSION 3.0.0 )
 
 project(clandmark)
 
 # The version number
 set(clandmark_VERSION_MAJOR 1)
 set(clandmark_VERSION_MINOR 5)
+set(clandmark_VERSION ${clandmark_VERSION_MAJOR}.${clandmark_VERSION_MINOR})
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules")
 
@@ -57,4 +58,32 @@ endif(BUILD_MATLAB_BINDINGS)
 if(BUILD_PYTHON_BINDINGS)
     add_subdirectory(python_interface)
 endif(BUILD_PYTHON_BINDINGS)
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/clandmark/CLandmarkConfigVersion.cmake"
+    VERSION ${clandmark_VERSION}
+    COMPATIBILITY AnyNewerVersion
+)
+export(EXPORT CLandmarkTargets
+    FILE "${CMAKE_CURRENT_BINARY_DIR}/clandmark/CLandmarkTargets.cmake"
+    NAMESPACE CLandmark::
+)
+configure_file(cmake/Templates/CLandmarkConfig.cmake
+    "${CMAKE_CURRENT_BINARY_DIR}/clandmark/CLandmarkConfig.cmake"
+    COPYONLY
+)
+install(EXPORT CLandmarkTargets
+    FILE CLandmarkTargets.cmake
+    NAMESPACE CLandmark::
+    DESTINATION clandmark/lib/cmake/clandmark
+)
+install(
+    FILES
+    cmake/Templates/CLandmarkConfig.cmake
+    "${CMAKE_CURRENT_BINARY_DIR}/clandmark/CLandmarkConfigVersion.cmake"
+    DESTINATION clandmark/lib/cmake/clandmark
+    COMPONENT Devel
+)
+
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,10 +58,3 @@ if(BUILD_PYTHON_BINDINGS)
     add_subdirectory(python_interface)
 endif(BUILD_PYTHON_BINDINGS)
 
-# propagate precision definition
-if(DOUBLE_PRECISION)
-    add_definitions( -DDOUBLE_PRECISION=1 )
-else(DOUBLE_PRECISION)
-    add_definitions( -DDOUBLE_PRECISION=0 )
-endif(DOUBLE_PRECISION)
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,9 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wall -pedantic")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -pedantic")
 
+# for configured header files:
+include_directories(${PROJECT_BINARY_DIR})
+
 # build clandmark
 add_subdirectory (libclandmark)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,13 +76,13 @@ configure_file(cmake/Templates/CLandmarkConfig.cmake
 install(EXPORT CLandmarkTargets
     FILE CLandmarkTargets.cmake
     NAMESPACE CLandmark::
-    DESTINATION clandmark/lib/cmake/clandmark
+    DESTINATION lib/cmake/clandmark
 )
 install(
     FILES
     cmake/Templates/CLandmarkConfig.cmake
     "${CMAKE_CURRENT_BINARY_DIR}/clandmark/CLandmarkConfigVersion.cmake"
-    DESTINATION clandmark/lib/cmake/clandmark
+    DESTINATION lib/cmake/clandmark
     COMPONENT Devel
 )
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@
 
 Detailed description will be added soon
 
+## Dependencies
+
+### libclandmark
+
+ - CImg (>= 1.5.6)
+ - RapidXML (1.13)
+
+If any of these libraries are installed in a known system prefix, CLandmark will try to use the already installed version.
+Otherwise, the internal version will be used and its files will be installed alongside CLandmark.
+
+**CAVEAT**: The version of RapidXML that comes with CLandmark has been changed to fix some missing forward declarations.
+
 ## References
 
 In case you use clandmark in an academic work, please cite the following paper:

--- a/cmake/Modules/FindCImg.cmake
+++ b/cmake/Modules/FindCImg.cmake
@@ -1,0 +1,19 @@
+# - Try to find Cimg
+# Once done this will define
+#  CIMG_FOUND - System has CImg
+#  CImg_INCLUDE_DIR - The CImg include directories
+
+find_path(CImg_INCLUDE_DIR CImg.h)
+
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set CIMG_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args(CImg DEFAULT_MSG CImg_INCLUDE_DIR)
+
+mark_as_advanced(CImg_INCLUDE_DIR)
+
+if(CIMG_FOUND)
+    # provide import target:
+    add_library(CImg::CImg INTERFACE IMPORTED)
+    set_target_properties(CImg::CImg PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${CImg_INCLUDE_DIR})
+endif()

--- a/cmake/Modules/FindRapidXML.cmake
+++ b/cmake/Modules/FindRapidXML.cmake
@@ -3,7 +3,7 @@
 #  RAPIDXML_FOUND - System has RapidXML
 #  RapidXML_INCLUDE_DIR - The RapidXML include directories
 
-find_path(RapidXML_INCLUDE_DIR rapidxml.hpp)
+find_path(RapidXML_INCLUDE_DIR rapidxml.hpp PATH_SUFFIXES rapidxml)
 
 include(FindPackageHandleStandardArgs)
 # handle the QUIETLY and REQUIRED arguments and set RAPIDXML_FOUND to TRUE

--- a/cmake/Modules/FindRapidXML.cmake
+++ b/cmake/Modules/FindRapidXML.cmake
@@ -1,0 +1,19 @@
+# - Try to find RapidXML
+# Once done this will define
+#  RAPIDXML_FOUND - System has RapidXML
+#  RapidXML_INCLUDE_DIR - The RapidXML include directories
+
+find_path(RapidXML_INCLUDE_DIR rapidxml.hpp)
+
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set RAPIDXML_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args(RapidXML DEFAULT_MSG RapidXML_INCLUDE_DIR)
+
+mark_as_advanced(RapidXML_INCLUDE_DIR)
+
+if(RAPIDXML_FOUND)
+    # provide import target:
+	 add_library(RapidXML::RapidXML INTERFACE IMPORTED)
+	 set_target_properties(RapidXML::RapidXML PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${RapidXML_INCLUDE_DIR})
+endif()

--- a/cmake/Templates/CLandmarkConfig.cmake
+++ b/cmake/Templates/CLandmarkConfig.cmake
@@ -1,0 +1,1 @@
+include("${CMAKE_CURRENT_LIST_DIR}/CLandmarkTargets.cmake")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -13,5 +13,5 @@ foreach(var ${EXAMPLES})
     target_link_libraries(${var} flandmark ${OpenCV_LIBS})
 endforeach()
 
-install(TARGETS ${EXAMPLES} EXPORT CLandmarkTargets DESTINATION clandmark/examples COMPONENT Examples)
+install(TARGETS ${EXAMPLES} EXPORT CLandmarkTargets DESTINATION share/clandmark/examples COMPONENT Examples)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -13,5 +13,5 @@ foreach(var ${EXAMPLES})
     target_link_libraries(${var} flandmark ${OpenCV_LIBS})
 endforeach()
 
-install(TARGETS ${EXAMPLES} DESTINATION clandmark/examples)
+install(TARGETS ${EXAMPLES} EXPORT CLandmarkTargets DESTINATION clandmark/examples COMPONENT Examples)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -6,13 +6,6 @@ include_directories(${OpenCV_INCLUDE_DIR})
 include_directories(${PROJECT_SOURCE_DIR}/3rd_party/rapidxml-1.13)
 include_directories(${PROJECT_SOURCE_DIR}/3rd_party/CImg-1.5.6)
 
-# propagate precision definition
-if(DOUBLE_PRECISION)
-    add_definitions( -DDOUBLE_PRECISION=1 )
-else(DOUBLE_PRECISION)
-    add_definitions( -DDOUBLE_PRECISION=0 )
-endif(DOUBLE_PRECISION)
-
 ## Several examples using flandmark
 set(EXAMPLES static_input video_input)
 foreach(var ${EXAMPLES})

--- a/libclandmark/CLandmarkConfig.h.in
+++ b/libclandmark/CLandmarkConfig.h.in
@@ -1,0 +1,16 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ */
+// this file is automatically created
+
+#ifndef _CLANDMARKCONFIG__H__
+#define _CLANDMARKCONFIG__H__
+
+#cmakedefine DOUBLE_PRECISION 1
+
+#endif /* _CLANDMARKCONFIG__H__ */
+

--- a/libclandmark/CMakeLists.txt
+++ b/libclandmark/CMakeLists.txt
@@ -4,12 +4,12 @@ if(NOT RAPIDXML_FOUND)
    message(STATUS "RapidXML not found - using internal version.")
 	set(RapidXML_INCLUDE_DIR "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/3rd_party/rapidxml-1.13/>" CACHE PATH "Include directory for RapidXML" FORCE)
    file(GLOB RapidXML_HEADERS ${PROJECT_SOURCE_DIR}/3rd_party/rapidxml-1.13/*.hpp)
-   install(FILES ${RapidXML_HEADERS} DESTINATION clandmark/include COMPONENT Devel)
+   install(FILES ${RapidXML_HEADERS} DESTINATION include COMPONENT Devel)
    install(
       FILES
       ${PROJECT_SOURCE_DIR}/3rd_party/rapidxml-1.13/manual.html
       ${PROJECT_SOURCE_DIR}/3rd_party/rapidxml-1.13/license.txt
-      DESTINATION clandmark/share/doc COMPONENT Devel)
+      DESTINATION share/doc COMPONENT Devel)
 endif()
 
 # prefer preinstalled CImg:
@@ -18,9 +18,9 @@ if(NOT CIMG_FOUND)
     message(STATUS "CImg not found - using internal version.")
     set(CImg_INCLUDE_DIR "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/3rd_party/CImg-1.5.6/>" CACHE PATH "Include directory for CImg" FORCE)
     install(FILES ${PROJECT_SOURCE_DIR}/3rd_party/CImg-1.5.6/CImg.h
-        DESTINATION clandmark/include COMPONENT Devel)
+        DESTINATION include COMPONENT Devel)
     file(GLOB CImg_DOCS ${PROJECT_SOURCE_DIR}/3rd_party/CImg-1.5.6/*.txt)
-    install(FILES ${CImg_DOCS} DESTINATION clandmark/share/doc COMPONENT Devel)
+    install(FILES ${CImg_DOCS} DESTINATION share/doc COMPONENT Devel)
 endif()
 
 configure_file(
@@ -125,14 +125,14 @@ set(flandmark_models
 
 install(TARGETS clandmark flandmark
     EXPORT CLandmarkTargets
-	 LIBRARY DESTINATION clandmark/lib
-	 ARCHIVE DESTINATION clandmark/lib
-	 RUNTIME DESTINATION clandmark/bin
-    INCLUDES DESTINATION clandmark/include
+	 LIBRARY DESTINATION lib
+	 ARCHIVE DESTINATION lib
+	 RUNTIME DESTINATION bin
+    INCLUDES DESTINATION include
 )
-install(FILES ${clandmark_headers} DESTINATION clandmark/include COMPONENT Devel)
-install(FILES ${flandmark_headers} DESTINATION clandmark/include COMPONENT Devel)
-install(FILES ${flandmark_models} DESTINATION clandmark/models)
+install(FILES ${clandmark_headers} DESTINATION include COMPONENT Devel)
+install(FILES ${flandmark_headers} DESTINATION include COMPONENT Devel)
+install(FILES ${flandmark_models} DESTINATION share/clandmark/models)
 
 # deprecated:
 ##setup Config.cmake

--- a/libclandmark/CMakeLists.txt
+++ b/libclandmark/CMakeLists.txt
@@ -85,11 +85,8 @@ target_link_libraries(clandmark)
 set_target_properties(clandmark PROPERTIES POSITION_INDEPENDENT_CODE TRUE)	# -fPIC
 set_target_properties(clandmark PROPERTIES
     SOVERSION "${clandmark_VERSION_MAJOR}"
-    VERSION "${clandmark_VERSION_MAJOR}.${clandmark_VERSION_MINOR}"
+    VERSION "${clandmark_VERSION}"
 )
-
-install(TARGETS clandmark DESTINATION clandmark/bin)
-install(FILES ${clandmark_headers} DESTINATION clandmark/include)
 
 # FLANDMARK
 add_library(flandmark ${flandmark_srcs})
@@ -100,7 +97,7 @@ target_link_libraries(flandmark clandmark)
 set_target_properties(flandmark PROPERTIES POSITION_INDEPENDENT_CODE TRUE)	# -fPIC
 set_target_properties(flandmark PROPERTIES
     SOVERSION "${clandmark_VERSION_MAJOR}"
-    VERSION "${clandmark_VERSION_MAJOR}.${clandmark_VERSION_MINOR}"
+    VERSION "${clandmark_VERSION}"
 )
 
 # Models learned distributed with CLandmark
@@ -109,23 +106,31 @@ set(flandmark_models
     ${CMAKE_SOURCE_DIR}/data/haarcascade_frontalface_alt.xml
 )
 
-install(TARGETS flandmark DESTINATION clandmark/bin)
-install(FILES ${flandmark_headers} DESTINATION clandmark/include)
+install(TARGETS clandmark flandmark
+    EXPORT CLandmarkTargets
+	 LIBRARY DESTINATION clandmark/lib
+	 ARCHIVE DESTINATION clandmark/lib
+	 RUNTIME DESTINATION clandmark/bin
+    INCLUDES DESTINATION clandmark/include
+)
+install(FILES ${clandmark_headers} DESTINATION clandmark/include COMPONENT Devel)
+install(FILES ${flandmark_headers} DESTINATION clandmark/include COMPONENT Devel)
 install(FILES ${flandmark_models} DESTINATION clandmark/models)
 
-#setup Config.cmake
-set(CLANDMARK_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/libclandmark" "${PROJECT_SOURCE_DIR}/3rd_party/rapidxml-1.13" "${PROJECT_SOURCE_DIR}/3rd_party/CImg-1.5.6")
-get_property(CLANDMARK_LIBRARIES TARGET clandmark PROPERTY LOCATION)
-configure_file(clandmarkConfig.cmake.in
-    "${PROJECT_BINARY_DIR}/libclandmark/clandmarkConfig.cmake" @ONLY
-)
-
-export(PACKAGE clandmark)
-
-set(FLANDMARK_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/libclandmark" "${PROJECT_SOURCE_DIR}/3rd_party/rapidxml-1.13" "${PROJECT_SOURCE_DIR}/3rd_party/CImg-1.5.6")
-get_property(FLANDMARK_LIBRARIES TARGET flandmark PROPERTY LOCATION)
-configure_file(flandmarkConfig.cmake.in
-    "${PROJECT_BINARY_DIR}/libclandmark/flandmarkConfig.cmake" @ONLY
-)
-
-export(PACKAGE flandmark)
+# deprecated:
+##setup Config.cmake
+#set(CLANDMARK_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/libclandmark" "${PROJECT_SOURCE_DIR}/3rd_party/rapidxml-1.13" "${PROJECT_SOURCE_DIR}/3rd_party/CImg-1.5.6")
+#get_property(CLANDMARK_LIBRARIES TARGET clandmark PROPERTY LOCATION)
+#configure_file(clandmarkConfig.cmake.in
+#    "${PROJECT_BINARY_DIR}/libclandmark/clandmarkConfig.cmake" @ONLY
+#)
+#
+#export(PACKAGE clandmark)
+#
+#set(FLANDMARK_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/libclandmark" "${PROJECT_SOURCE_DIR}/3rd_party/rapidxml-1.13" "${PROJECT_SOURCE_DIR}/3rd_party/CImg-1.5.6")
+#get_property(FLANDMARK_LIBRARIES TARGET flandmark PROPERTY LOCATION)
+#configure_file(flandmarkConfig.cmake.in
+#    "${PROJECT_BINARY_DIR}/libclandmark/flandmarkConfig.cmake" @ONLY
+#)
+#
+#export(PACKAGE flandmark)

--- a/libclandmark/CMakeLists.txt
+++ b/libclandmark/CMakeLists.txt
@@ -4,13 +4,10 @@ aux_source_directory(${PROJECT_SOURCE_DIR}/3rd_party/rapidxml-1.13 RAPIDXML)
 include_directories(${PROJECT_SOURCE_DIR}/3rd_party/CImg-1.5.6)
 aux_source_directory(${PROJECT_SOURCE_DIR}/3rd_party/CImg-1.5.6 CIMG)
 
-# propagate precision definition
-if(DOUBLE_PRECISION)
-    add_definitions( -DDOUBLE_PRECISION=1 )
-else(DOUBLE_PRECISION)
-    add_definitions( -DDOUBLE_PRECISION=0 )
-endif(DOUBLE_PRECISION)
-
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/CLandmarkConfig.h.in
+    ${PROJECT_BINARY_DIR}/CLandmarkConfig.h
+)
 set(clandmark_headers
     ${CIMG}
     ${RAPIDXML}
@@ -26,6 +23,7 @@ set(clandmark_headers
     CXMLInOut.h
     CTimer.h
     CTypes.h
+    ${PROJECT_BINARY_DIR}/CLandmarkConfig.h
 )
 
 set(clandmark_srcs

--- a/libclandmark/CMakeLists.txt
+++ b/libclandmark/CMakeLists.txt
@@ -9,7 +9,7 @@ if(NOT RAPIDXML_FOUND)
       FILES
       ${PROJECT_SOURCE_DIR}/3rd_party/rapidxml-1.13/manual.html
       ${PROJECT_SOURCE_DIR}/3rd_party/rapidxml-1.13/license.txt
-      DESTINATION share/doc COMPONENT Devel)
+      DESTINATION share/doc/clandmark COMPONENT Devel)
 endif()
 
 # prefer preinstalled CImg:
@@ -20,7 +20,7 @@ if(NOT CIMG_FOUND)
     install(FILES ${PROJECT_SOURCE_DIR}/3rd_party/CImg-1.5.6/CImg.h
         DESTINATION include COMPONENT Devel)
     file(GLOB CImg_DOCS ${PROJECT_SOURCE_DIR}/3rd_party/CImg-1.5.6/*.txt)
-    install(FILES ${CImg_DOCS} DESTINATION share/doc COMPONENT Devel)
+    install(FILES ${CImg_DOCS} DESTINATION share/doc/clandmark COMPONENT Devel)
 endif()
 
 configure_file(

--- a/libclandmark/CMakeLists.txt
+++ b/libclandmark/CMakeLists.txt
@@ -1,15 +1,32 @@
-# prefer preinstalled RapidXML:
+# prefer preinstalled RapidXML...
 find_package(RapidXML)
+
+if(RAPIDXML_FOUND)
+    #...but check for known upstream bugs:
+    include(CheckCXXSourceCompiles)
+    set(CMAKE_REQUIRED_INCLUDES_BAK "${CMAKE_REQUIRED_INCLUDES}")
+    list(APPEND CMAKE_REQUIRED_INCLUDES "${RapidXML_INCLUDE_DIR}")
+    check_cxx_source_compiles(
+		 "#include <rapidxml_print.hpp>\nint main() { rapidxml::xml_document<> doc; std::string test; rapidxml::print(std::back_inserter(test), doc); return 0; }"
+        RAPIDXML_PRINT_HEADER_OK
+    )
+    if(NOT RAPIDXML_PRINT_HEADER_OK)
+       # issue a fatal error here - if we were to use the internal version, we might overwrite the other installation
+       message(FATAL_ERROR "RapidXML found but not usable! Please remove preinstalled version.")
+    endif()
+endif()
+
 if(NOT RAPIDXML_FOUND)
-   message(STATUS "RapidXML not found - using internal version.")
-	set(RapidXML_INCLUDE_DIR "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/3rd_party/rapidxml-1.13/>" CACHE PATH "Include directory for RapidXML" FORCE)
-   file(GLOB RapidXML_HEADERS ${PROJECT_SOURCE_DIR}/3rd_party/rapidxml-1.13/*.hpp)
-   install(FILES ${RapidXML_HEADERS} DESTINATION include COMPONENT Devel)
-   install(
-      FILES
-      ${PROJECT_SOURCE_DIR}/3rd_party/rapidxml-1.13/manual.html
-      ${PROJECT_SOURCE_DIR}/3rd_party/rapidxml-1.13/license.txt
-      DESTINATION share/doc/clandmark COMPONENT Devel)
+    message(STATUS "RapidXML not found - using internal version.")
+    set(RapidXML_INCLUDE_DIR "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/3rd_party/rapidxml-1.13/>" CACHE PATH "Include directory for RapidXML" FORCE)
+    file(GLOB RapidXML_HEADERS ${PROJECT_SOURCE_DIR}/3rd_party/rapidxml-1.13/*.hpp)
+    install(FILES ${RapidXML_HEADERS} DESTINATION include COMPONENT Devel)
+    install(
+        FILES
+        ${PROJECT_SOURCE_DIR}/3rd_party/rapidxml-1.13/manual.html
+        ${PROJECT_SOURCE_DIR}/3rd_party/rapidxml-1.13/license.txt
+        DESTINATION share/doc/clandmark COMPONENT Devel
+    )
 endif()
 
 # prefer preinstalled CImg:

--- a/libclandmark/CMakeLists.txt
+++ b/libclandmark/CMakeLists.txt
@@ -1,15 +1,22 @@
 include_directories(${PROJECT_SOURCE_DIR}/3rd_party/rapidxml-1.13)
 aux_source_directory(${PROJECT_SOURCE_DIR}/3rd_party/rapidxml-1.13 RAPIDXML)
 
-include_directories(${PROJECT_SOURCE_DIR}/3rd_party/CImg-1.5.6)
-aux_source_directory(${PROJECT_SOURCE_DIR}/3rd_party/CImg-1.5.6 CIMG)
+# prefer preinstalled CImg:
+find_package(CImg)
+if(NOT CIMG_FOUND)
+    message(STATUS "CImg not found - using internal version.")
+    set(CImg_INCLUDE_DIR "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/3rd_party/CImg-1.5.6/>" CACHE PATH "Include directory for CImg" FORCE)
+    install(FILES ${PROJECT_SOURCE_DIR}/3rd_party/CImg-1.5.6/CImg.h
+        DESTINATION clandmark/include COMPONENT Devel)
+    file(GLOB CImg_DOCS ${PROJECT_SOURCE_DIR}/3rd_party/CImg-1.5.6/*.txt)
+    install(FILES ${CImg_DOCS} DESTINATION clandmark/share/doc COMPONENT Devel)
+endif()
 
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/CLandmarkConfig.h.in
     ${PROJECT_BINARY_DIR}/CLandmarkConfig.h
 )
 set(clandmark_headers
-    ${CIMG}
     ${RAPIDXML}
     msvc-compat.h
     base64.h
@@ -81,7 +88,7 @@ add_library(clandmark ${clandmark_srcs})
 if(NOT ${BUILD_SHARED_LIBS})
 	set_target_properties(clandmark PROPERTIES PREFIX "lib")
 endif()
-target_link_libraries(clandmark)
+target_include_directories(clandmark PUBLIC ${CImg_INCLUDE_DIR})
 set_target_properties(clandmark PROPERTIES POSITION_INDEPENDENT_CODE TRUE)	# -fPIC
 set_target_properties(clandmark PROPERTIES
     SOVERSION "${clandmark_VERSION_MAJOR}"

--- a/libclandmark/CMakeLists.txt
+++ b/libclandmark/CMakeLists.txt
@@ -1,5 +1,16 @@
-include_directories(${PROJECT_SOURCE_DIR}/3rd_party/rapidxml-1.13)
-aux_source_directory(${PROJECT_SOURCE_DIR}/3rd_party/rapidxml-1.13 RAPIDXML)
+# prefer preinstalled RapidXML:
+find_package(RapidXML)
+if(NOT RAPIDXML_FOUND)
+   message(STATUS "RapidXML not found - using internal version.")
+	set(RapidXML_INCLUDE_DIR "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/3rd_party/rapidxml-1.13/>" CACHE PATH "Include directory for RapidXML" FORCE)
+   file(GLOB RapidXML_HEADERS ${PROJECT_SOURCE_DIR}/3rd_party/rapidxml-1.13/*.hpp)
+   install(FILES ${RapidXML_HEADERS} DESTINATION clandmark/include COMPONENT Devel)
+   install(
+      FILES
+      ${PROJECT_SOURCE_DIR}/3rd_party/rapidxml-1.13/manual.html
+      ${PROJECT_SOURCE_DIR}/3rd_party/rapidxml-1.13/license.txt
+      DESTINATION clandmark/share/doc COMPONENT Devel)
+endif()
 
 # prefer preinstalled CImg:
 find_package(CImg)
@@ -17,7 +28,6 @@ configure_file(
     ${PROJECT_BINARY_DIR}/CLandmarkConfig.h
 )
 set(clandmark_headers
-    ${RAPIDXML}
     msvc-compat.h
     base64.h
     CLandmark.h
@@ -88,7 +98,7 @@ add_library(clandmark ${clandmark_srcs})
 if(NOT ${BUILD_SHARED_LIBS})
 	set_target_properties(clandmark PROPERTIES PREFIX "lib")
 endif()
-target_include_directories(clandmark PUBLIC ${CImg_INCLUDE_DIR})
+target_include_directories(clandmark PUBLIC ${CImg_INCLUDE_DIR} ${RapidXML_INCLUDE_DIR})
 set_target_properties(clandmark PROPERTIES POSITION_INDEPENDENT_CODE TRUE)	# -fPIC
 set_target_properties(clandmark PROPERTIES
     SOVERSION "${clandmark_VERSION_MAJOR}"

--- a/libclandmark/CTypes.h
+++ b/libclandmark/CTypes.h
@@ -14,6 +14,8 @@
 #include <cfloat>
 #include <limits>
 
+#include "CLandmarkConfig.h"
+
 namespace clandmark {
 
 // REDFINE DOUBLE_PRECISION AS FLOAT

--- a/matlab_interface/CMakeLists.txt
+++ b/matlab_interface/CMakeLists.txt
@@ -102,8 +102,8 @@ else(DOUBLE_PRECISION)
 	)
 endif(DOUBLE_PRECISION)
 
-install(FILES ${MEX_FILE_flandmark_interface} DESTINATION clandmark/mex COMPONENT Matlab)
-install(FILES ${MEX_FILE_featuresPool_interface} DESTINATION clandmark/mex COMPONENT Matlab)
+install(FILES ${MEX_FILE_flandmark_interface} DESTINATION share/clandmark/mex COMPONENT Matlab)
+install(FILES ${MEX_FILE_featuresPool_interface} DESTINATION share/clandmark/mex COMPONENT Matlab)
 
 	else()
 

--- a/matlab_interface/CMakeLists.txt
+++ b/matlab_interface/CMakeLists.txt
@@ -102,8 +102,8 @@ else(DOUBLE_PRECISION)
 	)
 endif(DOUBLE_PRECISION)
 
-	    install(FILES ${MEX_FILE_flandmark_interface} DESTINATION clandmark/mex)
-	    install(FILES ${MEX_FILE_featuresPool_interface} DESTINATION clandmark/mex)
+install(FILES ${MEX_FILE_flandmark_interface} DESTINATION clandmark/mex COMPONENT Matlab)
+install(FILES ${MEX_FILE_featuresPool_interface} DESTINATION clandmark/mex COMPONENT Matlab)
 
 	else()
 


### PR DESCRIPTION
Hi,

I've made some changes to clandmark to make it easier to use for other projects (and easier to package). The commits should be fairly self-explanatory, but here's the "executive summary":
- The definition of the macro `DOUBLE_PRECISION` is now written to a file, so that consumers don't have to know the correct value in order to link against clandmark.
-  A CLandmarkConfig.cmake file is provided so that find_package(CLandmark) works with an installed version of clandmark.
- exporting of the targets clandmark and flandmark in the build directory has been disabled
- If already installed, CImg and RapidXML will not be built internally

Could you please consider merging these changes into your clandmark repository?
